### PR TITLE
Add CUDA support for BoTorch

### DIFF
--- a/piglot/optimisers/botorch/bayes.py
+++ b/piglot/optimisers/botorch/bayes.py
@@ -135,7 +135,7 @@ class BayesianBoTorch(Optimiser):
         cv_error = None
         if self.n_test > 0:
             std_test_params = test_dataset.normalise(test_dataset.params)
-            std_test_values, _ = std_dataset.standardise(
+            std_test_values, _ = dataset.standardise(
                 test_dataset.values,
                 test_dataset.variances,
             )


### PR DESCRIPTION
Allow specifying the compute device for the PyTorch objects in BoTorch.
This allows running the optimisation in the GPU with CUDA which, locally, has been observed to be almost 6x faster than the CPU version.

However, GPU memory may be a limitation. Thus, when a CUDA out-of-memory error is raised, the optimisation falls back to the CPU automatically.

While there, fix an issue with standardising the test dataset in BoTorch.