### PR TITLE
Silence unsafe YAML loader warning

### DIFF
--- a/piglot/utils/yaml_parser.py
+++ b/piglot/utils/yaml_parser.py
@@ -43,7 +43,7 @@ def parse_config_file(config_file: str) -> Dict[str, Any]:
     """
     try:
         with open(config_file, 'r', encoding='utf8') as file:
-            config = yaml.load(file, Loader=UniqueKeyLoader)
+            config = yaml.load(file, Loader=UniqueKeyLoader)  # noseq B506
     except (ParserError, ScannerError) as exc:
         raise RuntimeError("Failed to parse the config file: YAML syntax seems invalid.") from exc
     # Check required terms

--- a/piglot/utils/yaml_parser.py
+++ b/piglot/utils/yaml_parser.py
@@ -43,7 +43,7 @@ def parse_config_file(config_file: str) -> Dict[str, Any]:
     """
     try:
         with open(config_file, 'r', encoding='utf8') as file:
-            config = yaml.load(file, Loader=UniqueKeyLoader)  # noseq B506
+            config = yaml.load(file, Loader=UniqueKeyLoader)  # nosec B506
     except (ParserError, ScannerError) as exc:
         raise RuntimeError("Failed to parse the config file: YAML syntax seems invalid.") from exc
     # Check required terms


### PR DESCRIPTION
Our `UniqueKeyLoader` inherits from the `yaml.SafeLoader` class, but it is flagged as unsafe by Bandit.
This silences the false positive.