### PR TITLE
Optimised Abaqus interface

### DIFF
--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -112,8 +112,7 @@ class AbaqusInputData(InputData):
             instance_list = re.findall(r'\*Instance, name=([^,]+)', data)
             self.instance_name = self.__sanitize_field(self.instance_name,
                                                        instance_list,
-                                                       "instance"
-                                                    )
+                                                       "instance")
 
             step_list = re.findall(r'\*Step, name=([^,]+)', data)
             self.step_name = self.__sanitize_field(self.step_name, step_list, "step")

--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -111,8 +111,10 @@ class AbaqusInputData(InputData):
             self.job_name = self.__sanitize_field(self.job_name, job_list, "job")
 
             instance_list = re.findall(r'\*Instance, name=([^,]+)', data)
-            self.instance_name = self.__sanitize_field(self.instance_name, instance_list,
-                                                       "instance")
+            self.instance_name = self.__sanitize_field(self.instance_name.upper(),
+                                                       instance_list,
+                                                       "instance"
+                                                    )
 
             step_list = re.findall(r'\*Step, name=([^,]+)', data)
             self.step_name = self.__sanitize_field(self.step_name, step_list, "step")

--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -111,7 +111,7 @@ class AbaqusInputData(InputData):
             self.job_name = self.__sanitize_field(self.job_name, job_list, "job")
 
             instance_list = re.findall(r'\*Instance, name=([^,]+)', data)
-            self.instance_name = self.__sanitize_field(self.instance_name.upper(),
+            self.instance_name = self.__sanitize_field(self.instance_name,
                                                        instance_list,
                                                        "instance"
                                                     )

--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -234,12 +234,6 @@ class FieldsOutput(OutputField):
         data_group = data[columns].to_numpy()
         y_field = reduction[self.field](data_group, axis=1)
 
-        # Delete the extra temporary files
-        files = glob.glob(output_dir + '/' + input_file + '*.txt')
-        for file in files:
-            if self.set_name not in file:
-                os.remove(file)
-
         return OutputResult(x_field, y_field)
 
     @staticmethod

--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -97,7 +97,7 @@ class AbaqusInputData(InputData):
         """
         # Generate a dummy set of parameters (to ensure proper handling of output parameters)
         values = np.array([parameter.inital_value for parameter in parameters])
-        param_dict = parameters.to_dict(values, input_normalised=False)
+        param_dict = parameters.to_dict(values)
         for name in param_dict:
             if not has_parameter(self.input_file, f'<{name}>'):
                 raise RuntimeError(f"Parameter '{name}' not found in input file.")

--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Dict, Any, List
 import os
 import re
-import glob
 import numpy as np
 import pandas as pd
 from piglot.parameter import ParameterSet

--- a/piglot/solver/abaqus/fields.py
+++ b/piglot/solver/abaqus/fields.py
@@ -180,7 +180,7 @@ class FieldsOutput(OutputField):
         with open(input_file + ext, 'r', encoding='utf-8') as file:
             data = file.read()
 
-            nsets_list = re.findall(r'\*Nset, nset=([^,]+)', data)
+            nsets_list = re.findall(r'\*Nset, nset="?([^",\s]+)"?', data)
             if len(nsets_list) == 0:
                 raise ValueError("No sets found in the file.")
             if self.set_name not in nsets_list:

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -27,28 +27,20 @@ def input_variables():
     x_field_list = [a for a in args if a.startswith("x_field=")]
 
     # Checks if the input_file, job_name, step_name and instance_name are not empty
-    input_file = input_file_list[0].replace('input_file=', '') \
+    variables['input_file'] = input_file_list[0].replace('input_file=', '') \
         if input_file_list else None
-    job_name = job_name_list[0].replace('job_name=', '') \
+    variables['job_name'] = job_name_list[0].replace('job_name=', '') \
         if job_name_list else None
-    step_name = step_name_list[0].replace('step_name=', '') \
+    variables['step_name'] = step_name_list[0].replace('step_name=', '') \
         if step_name_list else None
-    instance_name = instance_name_list[0].replace('instance_name=', '') \
+    variables['instance_name'] = instance_name_list[0].replace('instance_name=', '') \
         if instance_name_list else None
-    set_name = set_name_list[0].replace('set_name=', '') \
+    variables['set_name'] = set_name_list[0].replace('set_name=', '') \
         if set_name_list else None
-    field = field_list[0].replace('field=', '') \
+    variables['field'] = field_list[0].replace('field=', '') \
         if field_list else None
-    x_field = x_field_list[0].replace('x_field=', '') \
+    variables['x_field']  = x_field_list[0].replace('x_field=', '') \
         if x_field_list else None
-
-    variables['input_file'] = input_file
-    variables['job_name'] = job_name
-    variables['step_name'] = step_name
-    variables['instance_name'] = instance_name
-    variables['set_name'] = set_name
-    variables['field'] = field
-    variables['x_field'] = x_field
 
     return variables
 

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -1,4 +1,6 @@
-"""Module to extract the nodal data from the output database (.odb) file"""
+"""Module to extract the nodal data from the output database (.odb) file
+Note: This script has older python syntax because it is used in Abaqus, which uses Python 2.7.
+"""
 import re
 import os
 import sys
@@ -18,13 +20,15 @@ def input_variables():
     args = sys.argv
     variables = {}
 
-    variable_names = ['input_file',
-                      'job_name',
-                      'step_name',
-                      'instance_name',
-                      'set_name',
-                      'field',
-                      'x_field']
+    variable_names = [
+        'input_file',
+        'job_name',
+        'step_name',
+        'instance_name',
+        'set_name',
+        'field',
+        'x_field',
+    ]
 
     for var_name in variable_names:
         var_list = [a for a in args if a.startswith(var_name + "=")]

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -27,8 +27,8 @@ def input_variables():
                       'x_field']
 
     for var_name in variable_names:
-        var_list = [a for a in args if a.startswith(f"{var_name}=")]
-        variables[var_name] = var_list[0].replace(f'{var_name}=', '') if var_list else None
+        var_list = [a for a in args if a.startswith(var_name + "=")]
+        variables[var_name] = var_list[0].replace(var_name + '=', '') if var_list else None
 
     return variables
 

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -39,7 +39,7 @@ def input_variables():
         if set_name_list else None
     variables['field'] = field_list[0].replace('field=', '') \
         if field_list else None
-    variables['x_field']  = x_field_list[0].replace('x_field=', '') \
+    variables['x_field'] = x_field_list[0].replace('x_field=', '') \
         if x_field_list else None
 
     return variables

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -109,7 +109,10 @@ def main():
     inp_name = variables["input_file"]
     job_name = variables["job_name"]
     step_name = variables["step_name"]
-    instance_name = variables["instance_name"]
+    if instance_name is not None:
+        instance_name = variables["instance_name"].upper()
+    else:
+        pass
     set_name_case = str(variables["set_name"])
     field = str(variables["field"])
     x_field = str(variables["x_field"])

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -218,12 +218,11 @@ def main():
     step = odb.steps[variables["step_name"]]
 
     for i, var in enumerate(variables_array):
-        variable = var
         node_sets = get_node_sets(instance_name, odb)
         for set_name, location in node_sets:
             if set_name == str(variables["set_name"]):
                 file_name = file_name_func(set_name, var, variables["input_file"])
-                write_output_file(i, variables_array, variable, step, location, file_name)
+                write_output_file(i, variables_array, var, step, location, file_name)
 
     odb.close()
 

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -133,7 +133,7 @@ def main():
             raise ValueError("'nlgeom' setting not found in the input file.")
 
     if nlgeom == 0 and (x_field == 'LE' or field == 'LE'):
-        raise ValueError("Error: 'LE' is not allowed when nlgeom is 0, use 'E' instead.")
+        raise ValueError("Error: 'LE' is not allowed when nlgeom is OFF, use 'E' instead.")
 
     variables_array = np.array([field, x_field])
 

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -74,7 +74,7 @@ def file_name_func(set_name, variable_name, inp_name):
     return file_name
 
 
-def field_location(i, output_variable, location):
+def field_location(output_variable, location):
     """It gets the node data of the specified node set.
 
     Parameters
@@ -91,7 +91,7 @@ def field_location(i, output_variable, location):
     location_output_variable
         Location of the output variable.
     """
-    if i in (0, 1):
+    if output_variable in ('S', 'E', 'LE'):
         location_output_variable = output_variable.getSubset(region=location,
                                                              position=ELEMENT_NODAL)
     else:
@@ -109,6 +109,7 @@ def main():
     inp_name = variables["input_file"]
     job_name = variables["job_name"]
     step_name = variables["step_name"]
+    instance_name = variables["instance_name"]
     if instance_name is not None:
         instance_name = variables["instance_name"].upper()
     else:
@@ -149,7 +150,7 @@ def main():
     # Create a variable that refers to the first step.
     step = odb.steps[step_name]
 
-    for i, var in enumerate(variables_array):
+    for var in variables_array:
 
         header_variable = "%s_%d"
         variable = var
@@ -173,7 +174,7 @@ def main():
                     # Create a variable that refers to the output variable of the node set. If the
                     # field is S or E it extrapolates the data to the nodes, if the field is U or RF
                     # the data is already on the nodes so it doesn't need extrapolation.
-                    location_output_variable = field_location(i, output_variable, location)
+                    location_output_variable = field_location(output_variable, location)
 
                     # Get the component labels
                     component_labels = output_variable.componentLabels
@@ -190,7 +191,7 @@ def main():
 
                         # Create a variable that refers to the output_variable of the node
                         # set in the current frame.
-                        location_output_variable = field_location(i, output_variable, location)
+                        location_output_variable = field_location(output_variable, location)
 
                         output_file.write("%d " % frame.frameId)
                         for v in location_output_variable.values:

--- a/piglot/solver/abaqus/reader.py
+++ b/piglot/solver/abaqus/reader.py
@@ -158,7 +158,7 @@ def get_node_sets(instance_name, odb):
 
     return odb.rootAssembly.nodeSets.items()
 
-def write_output_file(i, variables_array, step, location, file_name):
+def write_output_file(i, variables_array, variable, step, location, file_name):
     """Writes the output file with the nodal data of the specified node set.
 
     Parameters
@@ -175,27 +175,26 @@ def write_output_file(i, variables_array, step, location, file_name):
         It is a string that represents the name of the output file.
     """
     with codecs.open(file_name, 'w', encoding='utf-8') as output_file:
-        for var in variables_array:
-            output_variable = step.frames[0].fieldOutputs[var]
-            location_output_variable = field_location(i, variables_array, output_variable, location)
-            component_labels = output_variable.componentLabels
-            # Write the column headers dynamically based on the number of nodes and output
-            # variable components
-            header = "Frame " + " ".join("%s_%d" % (label, v.nodeLabel)
-                                         for v in location_output_variable.values
-                                         for label in component_labels) + "\n"
-            output_file.write(header)
-            for frame in step.frames:
-                output_variable = frame.fieldOutputs[var]
-                location_output_variable = field_location(i,
-                                                          variables_array,
-                                                          output_variable,
-                                                          location)
-                output_file.write("%d " % frame.frameId)
-                for v in location_output_variable.values:
-                    output_file.write(" ".join("%.9f" % value for value in v.data))
-                    output_file.write(" ")
-                output_file.write("\n")
+        output_variable = step.frames[0].fieldOutputs[variable]
+        location_output_variable = field_location(i, variables_array, output_variable, location)
+        component_labels = output_variable.componentLabels
+        # Write the column headers dynamically based on the number of nodes and output
+        # variable components
+        header = "Frame " + " ".join("%s_%d" % (label, v.nodeLabel)
+                                        for v in location_output_variable.values
+                                        for label in component_labels) + "\n"
+        output_file.write(header)
+        for frame in step.frames:
+            output_variable = frame.fieldOutputs[variable]
+            location_output_variable = field_location(i,
+                                                        variables_array,
+                                                        output_variable,
+                                                        location)
+            output_file.write("%d " % frame.frameId)
+            for v in location_output_variable.values:
+                output_file.write(" ".join("%.9f" % value for value in v.data))
+                output_file.write(" ")
+            output_file.write("\n")
 
 def main():
     """Main function to extract the nodal data from the output database (.odb) file.
@@ -219,11 +218,12 @@ def main():
     step = odb.steps[variables["step_name"]]
 
     for i, var in enumerate(variables_array):
+        variable = var
         node_sets = get_node_sets(instance_name, odb)
         for set_name, location in node_sets:
             if set_name == str(variables["set_name"]):
                 file_name = file_name_func(set_name, var, variables["input_file"])
-                write_output_file(i, variables_array, step, location, file_name)
+                write_output_file(i, variables_array, variable, step, location, file_name)
 
     odb.close()
 

--- a/piglot/solver/abaqus/solver.py
+++ b/piglot/solver/abaqus/solver.py
@@ -8,7 +8,7 @@ from multiprocessing.pool import ThreadPool as Pool
 import numpy as np
 from piglot.parameter import ParameterSet
 from piglot.solver.solver import Solver, Case, CaseResult, OutputField, OutputResult
-from piglot.solver.abaqus.fields import abaqus_fields_reader, AbaqusInputData
+from piglot.solver.abaqus.fields import abaqus_fields_reader, AbaqusInputData, FieldsOutput
 
 
 class AbaqusSolver(Solver):
@@ -47,13 +47,19 @@ class AbaqusSolver(Solver):
         self.tmp_dir = tmp_dir
         self.extra_args = extra_args
 
-    def _post_proc_variables(self, input_data: AbaqusInputData) -> Dict[str, Any]:
+    def _post_proc_variables(
+        self,
+        input_data: AbaqusInputData,
+        field_data: FieldsOutput
+    ) -> Dict[str, Any]:
         """Generate the post-processing variables.
 
         Parameters
         ----------
         input_data : AbaqusInputData
             Input data for the simulation.
+        field_data : FieldsOutput
+            Field data for the simulation.
 
         Returns
         -------
@@ -66,6 +72,9 @@ class AbaqusSolver(Solver):
         variables['job_name'] = input_data.job_name
         variables['step_name'] = input_data.step_name
         variables['instance_name'] = input_data.instance_name
+        variables['set_name'] = field_data.set_name
+        variables['field'] = field_data.field
+        variables['x_field'] = field_data.x_field
 
         return variables
 
@@ -94,8 +103,10 @@ class AbaqusSolver(Solver):
         os.mkdir(tmp_dir)
 
         # Copy input file replacing parameters by passed value
-        input_data = case.input_data.prepare(
-            values, self.parameters, tmp_dir=tmp_dir)
+        input_data = case.input_data.prepare(values,
+            self.parameters,
+            tmp_dir=tmp_dir
+        )
         input_file = input_data.input_file
 
         # Run ABAQUS (we don't use high precision timers here to keep track of the start time)
@@ -116,7 +127,7 @@ class AbaqusSolver(Solver):
             check=False
         )
 
-        variables = self._post_proc_variables(input_data)
+        variables = self._post_proc_variables(input_data, list(case.fields.values())[0])
         python_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'reader.py')
 
         run_odb = subprocess.run(
@@ -124,7 +135,11 @@ class AbaqusSolver(Solver):
              f"input_file={variables['input_file']}", "--",
              f"job_name={variables['job_name']}", "--",
              f"step_name={variables['step_name']}", "--",
-             f"instance_name={variables['instance_name']}"],
+             f"instance_name={variables['instance_name']}", "--",
+             f"set_name={variables['set_name']}", "--",
+             f"field={variables['field']}", "--",
+             f"x_field={variables['x_field']}"
+            ],
             cwd=tmp_dir,
             shell=False,
             stdout=subprocess.DEVNULL,

--- a/piglot/solver/abaqus/solver.py
+++ b/piglot/solver/abaqus/solver.py
@@ -103,10 +103,7 @@ class AbaqusSolver(Solver):
         os.mkdir(tmp_dir)
 
         # Copy input file replacing parameters by passed value
-        input_data = case.input_data.prepare(values,
-            self.parameters,
-            tmp_dir=tmp_dir
-        )
+        input_data = case.input_data.prepare(values, self.parameters, tmp_dir=tmp_dir)
         input_file = input_data.input_file
 
         # Run ABAQUS (we don't use high precision timers here to keep track of the start time)
@@ -138,8 +135,7 @@ class AbaqusSolver(Solver):
              f"instance_name={variables['instance_name']}", "--",
              f"set_name={variables['set_name']}", "--",
              f"field={variables['field']}", "--",
-             f"x_field={variables['x_field']}"
-            ],
+             f"x_field={variables['x_field']}"],
             cwd=tmp_dir,
             shell=False,
             stdout=subprocess.DEVNULL,

--- a/piglot/solver/abaqus/solver.py
+++ b/piglot/solver/abaqus/solver.py
@@ -139,6 +139,7 @@ class AbaqusSolver(Solver):
             cwd=tmp_dir,
             shell=False,
             stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             check=False
         )
         end_time = time.time()

--- a/piglot/solver/abaqus/solver.py
+++ b/piglot/solver/abaqus/solver.py
@@ -143,7 +143,6 @@ class AbaqusSolver(Solver):
             cwd=tmp_dir,
             shell=False,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             check=False
         )
         end_time = time.time()


### PR DESCRIPTION
- Optimised the way the field outputs are written and treated inside piglot. Now piglot only writes the fields and the set names that are present in the YAML file and automatically extrapolates to nodes units that are calculated at the integration points;
- Added errors to check for non-linear fields in linear simulations;
- Fixed some bugs on the implementation of the selected instance on abaqus;
- Generalised the reading of Abaqus input fiiles.